### PR TITLE
fix(Adjust Portfolio): remove an image under the Github Stats

### DIFF
--- a/Onyenso Goodluck Portfolio.md
+++ b/Onyenso Goodluck Portfolio.md
@@ -81,7 +81,7 @@ Here are some of my recent projects:
 ---
 
 ## 📊 GitHub Stats
-![Goodluck's GitHub Stats](https://github-readme-stats.vercel.app/api?username=Goody24&show_icons=true&theme=blueberry)
+
 ![Top Languages](https://github-readme-stats.vercel.app/api/top-langs/?username=Goody24&layout=compact&theme=blueberry)
 
 ---


### PR DESCRIPTION
I remove the statiscal diagram because it was not following the direction. In summary wrong data.